### PR TITLE
Run .net 8 extraction on windows 19/22

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       actions: read
       contents: read
@@ -34,6 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'csharp', 'javascript' ]
+        os: [ 'windows-2019', 'windows-2022', 'ubuntu-latest']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow file `.github/workflows/codeql-analysis.yml`. The changes allow the CodeQL analysis to run on multiple operating systems, specifically Windows 2019, Windows 2022, and Ubuntu latest.

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L27-R27): Modified the `runs-on` parameter under `jobs:` to use a matrix of operating systems, allowing the workflow to run on Windows 2019, Windows 2022, and Ubuntu latest. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L27-R27) [[2]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R37)